### PR TITLE
✨ feat: Google cloud Oauth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+event42sync.json
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,12 @@ dependencies {
 
     // Kotlinx Serialization for JSON handling
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+
+    // google
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.30.1")
+
+    //SLF4 error fix
+    implementation("org.slf4j:slf4j-nop:2.0.6")
 }
 
 application {


### PR DESCRIPTION
Add the authentication flow for Google Cloud and retrieve the access_token.

The Oauth flow is based on Service Account (SA), so we don't need credential or token handling. This protocol is based on server-to-server communication and will update the tokens automatically.

For this to work, we need to connect the SA and the specific Google Calendar we work with. This is done just by sharing the SA email as a user to the calendar.