### PR TITLE
:sparkles: feat: fetch hive events

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -80,8 +80,8 @@ fun main() = runBlocking {
         val accessGCToken = fetchGCAccessToken()
         println("GC Access Token: $accessGCToken")
 
-        val campus = fetchCampusData(access42Token)
-        printCampusDetails(campus)
+        val allCampuses = fetchAllCampusData(access42Token)
+        printAllCampuses(allCampuses)
     } catch (e: Exception) {
         println("Error occurred: ${e.message}")
     }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,14 +1,14 @@
+import com.google.auth.oauth2.ServiceAccountCredentials
+import io.github.cdimascio.dotenv.Dotenv
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.github.cdimascio.dotenv.Dotenv
-import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
-import io.ktor.client.request.forms.FormDataContent
 import io.ktor.util.*
-import com.google.auth.oauth2.ServiceAccountCredentials
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.io.FileInputStream
 
 @Serializable
@@ -74,12 +74,14 @@ fun fetchGCAccessToken(): String {
 fun main() = runBlocking {
     try {
         // Fetch the access token
-        val accessToken = fetch42AccessToken()
-        println("42 Access Token: $accessToken")
+        val access42Token = fetch42AccessToken()
+        println("42 Access Token: $access42Token")
 
         val accessGCToken = fetchGCAccessToken()
         println("GC Access Token: $accessGCToken")
 
+        val campus = fetchCampusData(access42Token)
+        printCampusDetails(campus)
     } catch (e: Exception) {
         println("Error occurred: ${e.message}")
     }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -12,6 +12,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.json.Json
 import java.io.FileInputStream
+import kotlinx.coroutines.delay
+import java.time.Instant
+
 
 @Serializable
 data class AccessTokenResponse(
@@ -48,7 +51,7 @@ suspend fun fetch42AccessToken(): String {
             }
             val responseBody = response.bodyAsText()
             println("42 Token Response: $responseBody")
-
+            delay(2000)
             // Extract access token from response
             val accessToken = extractAccessToken(responseBody)
             return accessToken
@@ -80,33 +83,25 @@ data class Event(
     val description: String,
     val location: String,
     val kind: String,
-    @SerialName("max_people") val maxPeople: Int? = null,
-    @SerialName("nbr_subscribers") val nbrSubscribers: Int,
     @SerialName("begin_at") val beginAt: String,
     @SerialName("end_at") val endAt: String,
     @SerialName("campus_ids") val campusIds: List<Int>,
     @SerialName("cursus_ids") val cursusIds: List<Int>,
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
-    @SerialName("prohibition_of_cancellation") val prohibitionOfCancellation: Int? = null,
-    val waitlist: Waitlist? = null,
-    val themes: List<String> = emptyList() // Default to an empty list if not provided
 )
 
-@Serializable
-data class Waitlist(
-    val id: Int,
-    @SerialName("waitlistable_id") val waitlistableId: Int,
-    @SerialName("waitlistable_type") val waitlistableType: String,
-    @SerialName("created_at") val createdAt: String,
-    @SerialName("updated_at") val updatedAt: String
-)
+val json = Json {
+    ignoreUnknownKeys = true
+}
 
 suspend fun fetchAllCampusEvents(access_token:String): List<Event> {
     val client = HttpClient(CIO)
     val allEvents = mutableListOf<Event>()
     var currentPage = 1
-    val pageSize = 30 // Number of results per page
+    val pageSize = 1 // Number of results per page
+    val currentTime = Instant.now()
+    var stopPagination = false
 
     try {
         while (true) {
@@ -114,6 +109,7 @@ suspend fun fetchAllCampusEvents(access_token:String): List<Event> {
             val response: HttpResponse = client.get("https://api.intra.42.fr/v2/campus/13/events") {
                 parameter("page[number]", currentPage) // Set page number
                 parameter("page[size]", pageSize) // Set page size
+                parameter("[sort]", "-begin_at")
                 headers {
                     append(HttpHeaders.Authorization, "Bearer $access_token")
                 }
@@ -131,12 +127,23 @@ suspend fun fetchAllCampusEvents(access_token:String): List<Event> {
             // Add campuses to the list
             allEvents.addAll(eventList)
 
-            // Check if this page had fewer items than `pageSize`, which means no more pages exist
-            if (eventList.size < pageSize) {
-                println("Last page reached. Stopping pagination.")
-                break
+            // Check each event's begin_at and compare with current time
+            for (event in eventList) {
+                val eventBeginAt = Instant.parse(event.beginAt) // Parse begin_at as Instant
+                if (eventBeginAt.isAfter(currentTime)) {
+                    continue
+                } else {
+                    stopPagination = true;
+                    break
+                }
             }
 
+            // Check if this page had fewer items than `pageSize`, which means no more pages exist
+            if (eventList.size < pageSize || stopPagination) {
+                println("Last page reached or events are older than today. Stopping pagination.")
+                break
+            }
+            delay(2000)
             // Move to the next page
             currentPage++
         }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,6 +1,7 @@
 import com.google.auth.oauth2.ServiceAccountCredentials
 import io.github.cdimascio.dotenv.Dotenv
 import io.ktor.client.*
+import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
@@ -8,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.util.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.json.Json
 import java.io.FileInputStream
 
@@ -71,6 +73,83 @@ fun fetchGCAccessToken(): String {
     return accessToken
 }
 
+@Serializable
+data class Event(
+    val id: Int,
+    val name: String,
+    val description: String,
+    val location: String,
+    val kind: String,
+    @SerialName("max_people") val maxPeople: Int? = null,
+    @SerialName("nbr_subscribers") val nbrSubscribers: Int,
+    @SerialName("begin_at") val beginAt: String,
+    @SerialName("end_at") val endAt: String,
+    @SerialName("campus_ids") val campusIds: List<Int>,
+    @SerialName("cursus_ids") val cursusIds: List<Int>,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("prohibition_of_cancellation") val prohibitionOfCancellation: Int? = null,
+    val waitlist: Waitlist? = null,
+    val themes: List<String> = emptyList() // Default to an empty list if not provided
+)
+
+@Serializable
+data class Waitlist(
+    val id: Int,
+    @SerialName("waitlistable_id") val waitlistableId: Int,
+    @SerialName("waitlistable_type") val waitlistableType: String,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+suspend fun fetchAllCampusEvents(access_token:String): List<Event> {
+    val client = HttpClient(CIO)
+    val allEvents = mutableListOf<Event>()
+    var currentPage = 1
+    val pageSize = 30 // Number of results per page
+
+    try {
+        while (true) {
+            // Make the GET request to the 42 API with pagination
+            val response: HttpResponse = client.get("https://api.intra.42.fr/v2/campus/13/events") {
+                parameter("page[number]", currentPage) // Set page number
+                parameter("page[size]", pageSize) // Set page size
+                headers {
+                    append(HttpHeaders.Authorization, "Bearer $access_token")
+                }
+            }
+
+            // Read response and check for empty body
+            val jsonString = response.bodyAsText()
+            if (jsonString.isEmpty()) {
+                throw Exception("Received empty response from the API")
+            }
+
+            // Parse JSON response as a list of campuses
+            val eventList = json.decodeFromString<List<Event>>(jsonString)
+
+            // Add campuses to the list
+            allEvents.addAll(eventList)
+
+            // Check if this page had fewer items than `pageSize`, which means no more pages exist
+            if (eventList.size < pageSize) {
+                println("Last page reached. Stopping pagination.")
+                break
+            }
+
+            // Move to the next page
+            currentPage++
+        }
+    } catch (e: Exception) {
+        println("Error occurred: ${e.message}")
+        throw e
+    } finally {
+        client.close()
+    }
+
+    return allEvents
+}
+
 fun main() = runBlocking {
     try {
         // Fetch the access token
@@ -80,8 +159,11 @@ fun main() = runBlocking {
         val accessGCToken = fetchGCAccessToken()
         println("GC Access Token: $accessGCToken")
 
-        val allCampuses = fetchAllCampusData(access42Token)
-        printAllCampuses(allCampuses)
+        val allEvents = fetchAllCampusEvents(access42Token)
+        allEvents.forEach { event ->
+            println(event.name)
+        }
+
     } catch (e: Exception) {
         println("Error occurred: ${e.message}")
     }

--- a/src/main/kotlin/tests.kt
+++ b/src/main/kotlin/tests.kt
@@ -16,10 +16,6 @@ data class Campus(
     val active: Boolean
 )
 
-val json = Json {
-    ignoreUnknownKeys = true
-}
-
 suspend fun fetchAllCampusData(access_token:String): List<Campus> {
     val client = HttpClient(CIO)
     val allCampuses = mutableListOf<Campus>()

--- a/src/main/kotlin/tests.kt
+++ b/src/main/kotlin/tests.kt
@@ -1,0 +1,60 @@
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.client.engine.cio.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class Campus(
+    val id: Int,
+    val name: String,
+    val country: String,
+    val users_count: Int,
+    val active: Boolean
+)
+
+val json = Json {
+    ignoreUnknownKeys = true
+}
+
+suspend fun fetchCampusData(access_token: String): Campus {
+    // Initialize Ktor client
+    val client = HttpClient(CIO)
+    try {
+    // Make GET request to 42 API campus endpoint
+    val response: HttpResponse = client.get("https://api.intra.42.fr/v2/campus") {
+        headers {
+            append(HttpHeaders.Authorization, "Bearer $access_token")
+        }
+    }
+
+    // Read response and check for empty body
+    val jsonString = response.bodyAsText()
+    if (jsonString.isEmpty()) {
+        throw Exception("Received empty response from the API")
+    }
+
+    // Parse JSON response, which is an array of campuses
+    val campusList = json.decodeFromString<List<Campus>>(jsonString)
+
+    // We assume there's only one campus in the response, retrieve the first element
+    return campusList.first()
+
+    } catch (e: Exception) {
+        println("Error occurred: ${e.message}")
+        throw e
+    } finally {
+        client.close()
+    }
+}
+
+fun printCampusDetails(campus: Campus) {
+    println("Campus ID: ${campus.id}")
+    println("Name: ${campus.name}")
+    println("Country: ${campus.country}")
+    println("Users Count: ${campus.users_count}")
+    println("Active: ${campus.active}")
+}


### PR DESCRIPTION
Fetch all events from Hive that are set in the future.

The main function for this patch is `fetchAllCampusEvents`, which sends a GET request to the Hive specific events end point (`https://api.intra.42.fr/v2/campus/13/events`) to fetch all the events. By the use of `sort` parameter, the call returns the events ordered based `begin_at`  parameter. The event that is most in the future will be the first one.

This call is paginated so the calls are repeated until the list is exhausted, or the events are in the past compared to the day of the request. The resulting JSON then has all the events set in the future.

