### PR TITLE
:sparkles: feat: post events to gcal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation("io.ktor:ktor-client-core:2.3.0")
     implementation("io.ktor:ktor-client-cio:2.3.0")
     implementation("io.ktor:ktor-client-serialization:2.3.0")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.0")
 
     // Dotenv for environment variable management
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.2")
@@ -30,6 +32,8 @@ dependencies {
 
     //SLF4 error fix
     implementation("org.slf4j:slf4j-nop:2.0.6")
+
+
 }
 
 application {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import kotlinx.serialization.json.*
 
 
 @Serializable
@@ -159,27 +160,25 @@ suspend fun fetchAllCampusEvents(access_token:String): List<Event> {
     return allEvents
 }
 
-fun Event.toGoogleCalendarEvent(): Map<String, Any> {
-    // Timezone hardcoded as Helsinki
+fun Event.toGoogleCalendarEvent(): JsonObject {
     val timeZone = "Europe/Helsinki"
 
-    // Convert beginAt and endAt to proper DateTime format (Google Calendar uses RFC3339)
     val startDateTime = ZonedDateTime.parse(beginAt).withZoneSameInstant(java.time.ZoneId.of(timeZone))
     val endDateTime = ZonedDateTime.parse(endAt).withZoneSameInstant(java.time.ZoneId.of(timeZone))
 
-    return mapOf(
-        "summary" to name,
-        "location" to location,
-        "description" to description,
-        "start" to mapOf(
-            "dateTime" to startDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-            "timeZone" to timeZone
-        ),
-        "end" to mapOf(
-            "dateTime" to endDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-            "timeZone" to timeZone
-        ),
-    )
+    return buildJsonObject {
+        put("summary", name)
+        put("location", location)
+        put("description", description)
+        put("start", buildJsonObject {
+            put("dateTime", startDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+            put("timeZone", timeZone)
+        })
+        put("end", buildJsonObject {
+            put("dateTime", endDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+            put("timeZone", timeZone)
+        })
+    }
 }
 
 


### PR DESCRIPTION
Upload all the 42 events into Google Calendar using a POST request.

The 42 events JSON is first converted into a JSON format that Google Calendar accept. Only the most basic members are now considered.

After that, a POST request is done for all the events using the desired `calendar_id` as the target.