### PR TITLE
:sparkles: feat: update events in gcal using put calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     //SLF4 error fix
     implementation("org.slf4j:slf4j-nop:2.0.6")
+    implementation("io.ktor:ktor-client-cio-jvm:2.3.0")
 
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,8 @@ dependencies {
     implementation("org.slf4j:slf4j-nop:2.0.6")
     implementation("io.ktor:ktor-client-cio-jvm:2.3.0")
 
-
+    // SQLlite
+    implementation("org.xerial:sqlite-jdbc:3.44.1.0")
 }
 
 application {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -304,7 +304,7 @@ suspend fun createGCalEvent(
         if (response.status.isSuccess()) {
             val responseBody = response.bodyAsText()
             val createdEvent = json.decodeFromString<EventGCal>(responseBody)
-            println("Successfully POST event: ${event.name}")
+            println("POST 42 ${event.name}")
             return createdEvent.id
         } else {
             println("Failed to POST event: ${response.status}")

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -270,14 +270,6 @@ suspend fun createGCalEvent(
     }
 }
 
-// Helper data class to store database event information
-data class EventDBInfo(
-    val gcalEventId: String,
-    val title: String,
-    val beginAt: String,
-    val lastUpdated: String
-)
-
 fun syncEvents(access42token: String, accessGCtoken: String) = runBlocking {
     println("Starting sync process...")
     val dbManager = DatabaseManager.getInstance()
@@ -289,14 +281,7 @@ fun syncEvents(access42token: String, accessGCtoken: String) = runBlocking {
         println("Found ${updatedEvents.size} events from 42")
 
         // 2. Get existing events from database
-        val dbEvents = dbManager.fetchEvents().associate { dbEvent ->
-            dbEvent.id.toInt() to EventDBInfo(
-                gcalEventId = dbEvent.gcalEventId,
-                title = dbEvent.title,
-                beginAt = dbEvent.beginAt,
-                lastUpdated = dbEvent.lastUpdated
-            )
-        }
+        val dbEvents = dbManager.fetchEvents().associateBy { dbEvent -> dbEvent.id.toInt() }
 
         // 3. Process each event from 42
         for (event42 in updatedEvents) {

--- a/src/main/kotlin/init.kt
+++ b/src/main/kotlin/init.kt
@@ -1,0 +1,247 @@
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+suspend fun fetchAllCampusEvents(access_token:String): List<Event42> {
+    val client = HttpClient(CIO)
+    val allEvent42s = mutableListOf<Event42>()
+    var currentPage = 1
+    val pageSize = 30 // Number of results per page
+    val zone = ZoneId.systemDefault() // Get system default time zone
+    // set current time as yesterday at midnight
+    // NB: value is relative to UTC. Modify by timezones as needed
+    val currentTime = LocalDate.now(zone)
+        .minusDays(30) // Move to the previous day (yesterday)
+        .atStartOfDay(zone) // Set to midnight of the previous day
+        .toInstant()
+    var stopPagination = false
+
+    try {
+        while (true) {
+            // Make the GET request to the 42 API with pagination
+            val response: HttpResponse = client.get("https://api.intra.42.fr/v2/campus/13/events") {
+                parameter("page[number]", currentPage) // Set page number
+                parameter("page[size]", pageSize) // Set page size
+                parameter("[sort]", "-begin_at")
+                headers {
+                    append(HttpHeaders.Authorization, "Bearer $access_token")
+                }
+            }
+
+            // Read response and check for empty body
+            val jsonString = response.bodyAsText()
+            if (jsonString.isEmpty()) {
+                throw Exception("Received empty response from the API")
+            }
+
+            // Parse JSON response as a list of campuses
+            val Event42List = json.decodeFromString<List<Event42>>(jsonString)
+
+            // Add campuses to the list
+            allEvent42s.addAll(Event42List)
+
+            // Check each event's begin_at and compare with current time
+            for (event in Event42List) {
+                val eventBeginAt = Instant.parse(event.beginAt) // Parse begin_at as Instant
+                if (eventBeginAt.isAfter(currentTime)) {
+                    continue
+                } else {
+                    stopPagination = true;
+                    break
+                }
+            }
+
+            // Check if this page had fewer items than `pageSize`, which means no more pages exist
+            if (Event42List.size < pageSize || stopPagination) {
+                println("Last page reached or events are older than today. Stopping pagination.")
+                break
+            }
+            delay(2000)
+            // Move to the next page
+            currentPage++
+        }
+    } catch (e: Exception) {
+        println("Error occurred: ${e.message}")
+        throw e
+    } finally {
+        client.close()
+    }
+
+    // Filter out events older than the threshold time
+    val filteredEvents = allEvent42s.filter { event ->
+        val eventBeginAt = Instant.parse(event.beginAt) // Parse begin_at as Instant
+        eventBeginAt.isAfter(currentTime) // Keep only events that are after the threshold
+    }
+
+    //Append ID to the description to use them as primary key when comparing events
+    val modifiedEvents = filteredEvents.map { event ->
+        event.copy(description = "${event.description}\n\nID: ${event.id}")
+    }
+    return modifiedEvents
+}
+
+// Database configuration object
+object DatabaseConfig {
+    const val DATABASE_URL = "jdbc:sqlite:events.db"
+
+    object Tables {
+        const val EVENTS = "events"
+    }
+
+    object Columns {
+        const val ID = "id"
+        const val GCAL_EVENT_ID = "gcal_event_id"
+        const val TITLE = "title"
+        const val BEGIN_AT ="begin_at"
+        const val LAST_UPDATED = "last_updated"
+    }
+}
+
+// Helper data class for database events
+data class DatabaseEvent(
+    val id: String,
+    val gcalEventId: String,
+    val title: String,
+    val beginAt: String,
+    val lastUpdated: String
+)
+
+class DatabaseManager private constructor() {
+    private var connection: Connection? = null
+
+    companion object {
+        @Volatile
+        private var instance: DatabaseManager? = null
+
+        init {
+            Class.forName("org.sqlite.JDBC")
+        }
+
+        fun getInstance(): DatabaseManager {
+            return instance ?: synchronized(this) {
+                instance ?: DatabaseManager().also {
+                    instance = it
+                    it.initializeDatabase()
+                }
+            }
+        }
+    }
+
+    private fun initializeDatabase() {
+        getConnection().createStatement().use { stmt ->
+            stmt.execute("""
+                CREATE TABLE IF NOT EXISTS ${DatabaseConfig.Tables.EVENTS} (
+                    ${DatabaseConfig.Columns.ID} INTEGER PRIMARY KEY,
+                    ${DatabaseConfig.Columns.GCAL_EVENT_ID} TEXT,
+                    ${DatabaseConfig.Columns.TITLE} TEXT,
+                    ${DatabaseConfig.Columns.BEGIN_AT} TEXT,
+                    ${DatabaseConfig.Columns.LAST_UPDATED} TEXT
+                )
+            """)
+        }
+    }
+
+    fun getConnection(): Connection {
+        return connection ?: synchronized(this) {
+            connection ?: DriverManager.getConnection(DatabaseConfig.DATABASE_URL).also {
+                connection = it
+            }
+        }
+    }
+
+    fun upsertEvent(id: Int, gcalEventId: String?, title: String, beginAt: String, lastUpdated: String) {
+        getConnection().prepareStatement("""
+            INSERT INTO ${DatabaseConfig.Tables.EVENTS} (
+                ${DatabaseConfig.Columns.ID}, 
+                ${DatabaseConfig.Columns.GCAL_EVENT_ID}, 
+                ${DatabaseConfig.Columns.TITLE},
+                ${DatabaseConfig.Columns.BEGIN_AT}, 
+                ${DatabaseConfig.Columns.LAST_UPDATED}
+            )
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(${DatabaseConfig.Columns.ID}) DO UPDATE SET
+                ${DatabaseConfig.Columns.GCAL_EVENT_ID} = excluded.${DatabaseConfig.Columns.GCAL_EVENT_ID},
+                ${DatabaseConfig.Columns.TITLE} = excluded.${DatabaseConfig.Columns.TITLE},
+                ${DatabaseConfig.Columns.BEGIN_AT} = excluded.${DatabaseConfig.Columns.BEGIN_AT},
+                ${DatabaseConfig.Columns.LAST_UPDATED} = excluded.${DatabaseConfig.Columns.LAST_UPDATED}
+        """).use { stmt ->
+            stmt.setInt(1, id)
+            stmt.setString(2, gcalEventId)
+            stmt.setString(3, title)
+            stmt.setString(4, beginAt)
+            stmt.setString(5, lastUpdated)
+            stmt.executeUpdate()
+        }
+    }
+
+    fun fetchEvents(): List<DatabaseEvent> {
+        return getConnection().createStatement().use { stmt ->
+            stmt.executeQuery("""
+            SELECT ${DatabaseConfig.Columns.ID}, 
+                   ${DatabaseConfig.Columns.GCAL_EVENT_ID},
+                   ${DatabaseConfig.Columns.TITLE},
+                   ${DatabaseConfig.Columns.BEGIN_AT},
+                   ${DatabaseConfig.Columns.LAST_UPDATED}
+            FROM ${DatabaseConfig.Tables.EVENTS}
+        """).use { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(DatabaseEvent(
+                            id = rs.getString(DatabaseConfig.Columns.ID),
+                            gcalEventId = rs.getString(DatabaseConfig.Columns.GCAL_EVENT_ID),
+                            title = rs.getString(DatabaseConfig.Columns.TITLE),
+                            beginAt = rs.getString(DatabaseConfig.Columns.BEGIN_AT),
+                            lastUpdated = rs.getString(DatabaseConfig.Columns.LAST_UPDATED)
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    fun closeConnection() {
+        connection?.close()
+        connection = null
+    }
+}
+
+fun initCalendar(accessGCtoken: String, access42token: String) = runBlocking {
+    try {
+        println("Deleting all calendar events...")
+        deleteAllEvents(accessGCtoken)
+
+        println("Fetching 42 events...")
+        val allEvents = fetchAllCampusEvents(access42token)
+        println("Total events fetched: ${allEvents.size}")
+
+        println("Initializing database...")
+        val dbManager = DatabaseManager.getInstance()
+
+        println("Uploading events to GCal...")
+        try {
+            for (event in allEvents) {
+                val eventGCalID = createGCalEvent(accessGCtoken, event)
+                try {
+                    dbManager.upsertEvent(event.id, eventGCalID, event.name, event.beginAt, event.updatedAt)
+                } catch (e: Exception) {
+                    println("Failed to save event ${event.id} to database: ${e.message}")
+                    break
+                }
+            }
+        } finally {
+            dbManager.closeConnection()
+        }
+    }
+    catch (e: Exception) {
+        println("Error occurred: ${e.message}")
+    }
+}

--- a/src/main/kotlin/utils.kt
+++ b/src/main/kotlin/utils.kt
@@ -225,6 +225,15 @@ object DatabaseConfig {
     }
 }
 
+// Helper data class for database events
+data class DatabaseEvent(
+    val id: String,
+    val gcalEventId: String,
+    val title: String,
+    val beginAt: String,
+    val lastUpdated: String
+)
+
 class DatabaseManager private constructor() {
     private var connection: Connection? = null
 
@@ -293,16 +302,25 @@ class DatabaseManager private constructor() {
         }
     }
 
-    fun fetchEvents(): List<Pair<String, String?>> {
+    fun fetchEvents(): List<DatabaseEvent> {
         return getConnection().createStatement().use { stmt ->
             stmt.executeQuery("""
-                SELECT ${DatabaseConfig.Columns.ID}, ${DatabaseConfig.Columns.GCAL_EVENT_ID} 
-                FROM ${DatabaseConfig.Tables.EVENTS}
-            """).use { rs ->
+            SELECT ${DatabaseConfig.Columns.ID}, 
+                   ${DatabaseConfig.Columns.GCAL_EVENT_ID},
+                   ${DatabaseConfig.Columns.TITLE},
+                   ${DatabaseConfig.Columns.BEGIN_AT},
+                   ${DatabaseConfig.Columns.LAST_UPDATED}
+            FROM ${DatabaseConfig.Tables.EVENTS}
+        """).use { rs ->
                 buildList {
                     while (rs.next()) {
-                        add(rs.getString(DatabaseConfig.Columns.ID) to
-                                rs.getString(DatabaseConfig.Columns.GCAL_EVENT_ID))
+                        add(DatabaseEvent(
+                            id = rs.getString(DatabaseConfig.Columns.ID),
+                            gcalEventId = rs.getString(DatabaseConfig.Columns.GCAL_EVENT_ID),
+                            title = rs.getString(DatabaseConfig.Columns.TITLE),
+                            beginAt = rs.getString(DatabaseConfig.Columns.BEGIN_AT),
+                            lastUpdated = rs.getString(DatabaseConfig.Columns.LAST_UPDATED)
+                        ))
                     }
                 }
             }

--- a/src/main/kotlin/utils.kt
+++ b/src/main/kotlin/utils.kt
@@ -7,6 +7,7 @@ import io.ktor.http.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -99,7 +100,8 @@ suspend fun deleteAllEvents(accessToken: String) {
     val calendarID = dotenv["calendar_id"]
     try {
         // Step 1: Fetch events
-        val response: HttpResponse = client.get("https://www.googleapis.com/calendar/v3/calendars/$calendarID/events") {
+        val response: HttpResponse = client.get("https://www.googleapis.com/calendar/v3/calendars/$calendarID/" +
+                "events?singleEvents=true") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
         }
 
@@ -111,6 +113,7 @@ suspend fun deleteAllEvents(accessToken: String) {
 
         // Step 2: Delete each event
         eventList.items.forEach { event ->
+            println("Deleting ${event.id}...")
             client.delete("https://www.googleapis.com/calendar/v3/calendars/$calendarID/events/${event.id}") {
                 header(HttpHeaders.Authorization, "Bearer $accessToken")
             }
@@ -208,13 +211,17 @@ fun initCalendar(accessGCtoken: String, access42token: String) = runBlocking {
         println("Deleting all calendar events...")
         deleteAllEvents(accessGCtoken)
 
-        println("Fetching 42 events...")
-        val allEvents =fetchAllCampusEvents(access42token)
-        println("Total events fetched: ${allEvents.size}")
-
-        println("Uploading events to Gcal...")
-        val googleCalendarEvents = allEvents.map { it.toGoogleCalendarEvent() }
-        insertCalendarEvents(accessGCtoken, googleCalendarEvents)
+//        println("Fetching 42 events...")
+//        val allEvents = fetchAllCampusEvents(access42token)
+//        println("Total events fetched: ${allEvents.size}")
+//
+//        println("Uploading events to Gcal...")
+//        val uploadEvents = allEvents.map {
+//            it.toGCalEvent()
+//        }
+//        val jsonEvent = Json.encodeToString(uploadEvents.first())
+//        println(jsonEvent)
+        //insertCalendarEvents(accessGCtoken, uploadEvents)
     }
     catch (e: Exception) {
         println("Error occurred: ${e.message}")

--- a/src/main/kotlin/utils.kt
+++ b/src/main/kotlin/utils.kt
@@ -12,6 +12,7 @@ import java.sql.DriverManager
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 
 /////////////// GET campus summary ///////////////
@@ -84,7 +85,54 @@ fun printAllCampuses(campuses: List<Campus>) {
     }
 }
 
-/////////////// DELETE all events ///////////////
+/////////////// GET all GCal events ///////////////
+
+suspend fun getGcalEvents(accessToken: String): List<EventGCal> {
+    val client = HttpClient(CIO)
+
+    val dotenv = Dotenv.load()
+    val calendarID = dotenv["calendar_id"]
+
+    val zone = ZoneId.systemDefault() // Get system default time zone
+    val currentTime = LocalDate.now(zone)
+        .minusDays(1) // Move to the previous day (yesterday)
+        .atStartOfDay(zone) // Set to midnight of the previous day
+        .toInstant()
+    // Format the current time in ISO 8601 format (UTC timezone) for the API
+    val formatter = DateTimeFormatter.ISO_INSTANT
+    val formattedTime = formatter.format(currentTime)
+    println(formattedTime)
+    try {
+        val response: HttpResponse = client.get(
+            "https://www.googleapis.com/calendar/v3/calendars/$calendarID/" +
+                    "events?singleEvents=true&timeMin=2024-12-26T22:00:00Z"
+        ) {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+
+        // Check if the response was successful
+        if (!response.status.isSuccess()) {
+            throw Exception("Failed to fetch events: ${response.status}")
+        }
+        println(response.bodyAsText())
+        val jsonString = response.bodyAsText()
+        if (jsonString.isEmpty()) {
+            println("No events found for the given time range.")
+            return emptyList() // Return empty list if no events found
+        }
+
+        // Deserialize the response JSON to a list of GCalEvent objects
+        val responseWrapper = json.decodeFromString<GCalEventsResponse>(jsonString)
+        return responseWrapper.items
+    } catch (e: Exception) {
+        println("Error occurred: ${e.message}")
+        return emptyList() // Return empty list in case of error
+    } finally {
+        client.close()
+    }
+}
+
+/////////////// DELETE all GCal events ///////////////
 
 // Data class for the event
 @Serializable
@@ -130,237 +178,4 @@ suspend fun deleteAllEvents(accessToken: String) {
 }
 
 
-suspend fun fetchAllCampusEvents(access_token:String): List<Event42> {
-    val client = HttpClient(CIO)
-    val allEvent42s = mutableListOf<Event42>()
-    var currentPage = 1
-    val pageSize = 30 // Number of results per page
-    val zone = ZoneId.systemDefault() // Get system default time zone
-    // set current time as yesterday at midnight
-    // NB: value is relative to UTC. Modify by timezones as needed
-    val currentTime = LocalDate.now(zone)
-        .minusDays(30) // Move to the previous day (yesterday)
-        .atStartOfDay(zone) // Set to midnight of the previous day
-        .toInstant()
-    var stopPagination = false
 
-    try {
-        while (true) {
-            // Make the GET request to the 42 API with pagination
-            val response: HttpResponse = client.get("https://api.intra.42.fr/v2/campus/13/events") {
-                parameter("page[number]", currentPage) // Set page number
-                parameter("page[size]", pageSize) // Set page size
-                parameter("[sort]", "-begin_at")
-                headers {
-                    append(HttpHeaders.Authorization, "Bearer $access_token")
-                }
-            }
-
-            // Read response and check for empty body
-            val jsonString = response.bodyAsText()
-            if (jsonString.isEmpty()) {
-                throw Exception("Received empty response from the API")
-            }
-
-            // Parse JSON response as a list of campuses
-            val Event42List = json.decodeFromString<List<Event42>>(jsonString)
-
-            // Add campuses to the list
-            allEvent42s.addAll(Event42List)
-
-            // Check each event's begin_at and compare with current time
-            for (event in Event42List) {
-                val eventBeginAt = Instant.parse(event.beginAt) // Parse begin_at as Instant
-                if (eventBeginAt.isAfter(currentTime)) {
-                    continue
-                } else {
-                    stopPagination = true;
-                    break
-                }
-            }
-
-            // Check if this page had fewer items than `pageSize`, which means no more pages exist
-            if (Event42List.size < pageSize || stopPagination) {
-                println("Last page reached or events are older than today. Stopping pagination.")
-                break
-            }
-            delay(2000)
-            // Move to the next page
-            currentPage++
-        }
-    } catch (e: Exception) {
-        println("Error occurred: ${e.message}")
-        throw e
-    } finally {
-        client.close()
-    }
-
-    // Filter out events older than the threshold time
-    val filteredEvents = allEvent42s.filter { event ->
-        val eventBeginAt = Instant.parse(event.beginAt) // Parse begin_at as Instant
-        eventBeginAt.isAfter(currentTime) // Keep only events that are after the threshold
-    }
-
-    //Append ID to the description to use them as primary key when comparing events
-    val modifiedEvents = filteredEvents.map { event ->
-        event.copy(description = "${event.description}\n\nID: ${event.id}")
-    }
-    return modifiedEvents
-}
-
-// Database configuration object
-object DatabaseConfig {
-    const val DATABASE_URL = "jdbc:sqlite:events.db"
-
-    object Tables {
-        const val EVENTS = "events"
-    }
-
-    object Columns {
-        const val ID = "id"
-        const val GCAL_EVENT_ID = "gcal_event_id"
-        const val TITLE = "title"
-        const val BEGIN_AT ="begin_at"
-        const val LAST_UPDATED = "last_updated"
-    }
-}
-
-// Helper data class for database events
-data class DatabaseEvent(
-    val id: String,
-    val gcalEventId: String,
-    val title: String,
-    val beginAt: String,
-    val lastUpdated: String
-)
-
-class DatabaseManager private constructor() {
-    private var connection: Connection? = null
-
-    companion object {
-        @Volatile
-        private var instance: DatabaseManager? = null
-
-        init {
-            Class.forName("org.sqlite.JDBC")
-        }
-
-        fun getInstance(): DatabaseManager {
-            return instance ?: synchronized(this) {
-                instance ?: DatabaseManager().also {
-                    instance = it
-                    it.initializeDatabase()
-                }
-            }
-        }
-    }
-
-    private fun initializeDatabase() {
-        getConnection().createStatement().use { stmt ->
-            stmt.execute("""
-                CREATE TABLE IF NOT EXISTS ${DatabaseConfig.Tables.EVENTS} (
-                    ${DatabaseConfig.Columns.ID} INTEGER PRIMARY KEY,
-                    ${DatabaseConfig.Columns.GCAL_EVENT_ID} TEXT,
-                    ${DatabaseConfig.Columns.TITLE} TEXT,
-                    ${DatabaseConfig.Columns.BEGIN_AT} TEXT,
-                    ${DatabaseConfig.Columns.LAST_UPDATED} TEXT
-                )
-            """)
-        }
-    }
-
-    fun getConnection(): Connection {
-        return connection ?: synchronized(this) {
-            connection ?: DriverManager.getConnection(DatabaseConfig.DATABASE_URL).also {
-                connection = it
-            }
-        }
-    }
-
-    fun upsertEvent(id: Int, gcalEventId: String?, title: String, beginAt: String, lastUpdated: String) {
-        getConnection().prepareStatement("""
-            INSERT INTO ${DatabaseConfig.Tables.EVENTS} (
-                ${DatabaseConfig.Columns.ID}, 
-                ${DatabaseConfig.Columns.GCAL_EVENT_ID}, 
-                ${DatabaseConfig.Columns.TITLE},
-                ${DatabaseConfig.Columns.BEGIN_AT}, 
-                ${DatabaseConfig.Columns.LAST_UPDATED}
-            )
-            VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(${DatabaseConfig.Columns.ID}) DO UPDATE SET
-                ${DatabaseConfig.Columns.GCAL_EVENT_ID} = excluded.${DatabaseConfig.Columns.GCAL_EVENT_ID},
-                ${DatabaseConfig.Columns.TITLE} = excluded.${DatabaseConfig.Columns.TITLE},
-                ${DatabaseConfig.Columns.BEGIN_AT} = excluded.${DatabaseConfig.Columns.BEGIN_AT},
-                ${DatabaseConfig.Columns.LAST_UPDATED} = excluded.${DatabaseConfig.Columns.LAST_UPDATED}
-        """).use { stmt ->
-            stmt.setInt(1, id)
-            stmt.setString(2, gcalEventId)
-            stmt.setString(3, title)
-            stmt.setString(4, beginAt)
-            stmt.setString(5, lastUpdated)
-            stmt.executeUpdate()
-        }
-    }
-
-    fun fetchEvents(): List<DatabaseEvent> {
-        return getConnection().createStatement().use { stmt ->
-            stmt.executeQuery("""
-            SELECT ${DatabaseConfig.Columns.ID}, 
-                   ${DatabaseConfig.Columns.GCAL_EVENT_ID},
-                   ${DatabaseConfig.Columns.TITLE},
-                   ${DatabaseConfig.Columns.BEGIN_AT},
-                   ${DatabaseConfig.Columns.LAST_UPDATED}
-            FROM ${DatabaseConfig.Tables.EVENTS}
-        """).use { rs ->
-                buildList {
-                    while (rs.next()) {
-                        add(DatabaseEvent(
-                            id = rs.getString(DatabaseConfig.Columns.ID),
-                            gcalEventId = rs.getString(DatabaseConfig.Columns.GCAL_EVENT_ID),
-                            title = rs.getString(DatabaseConfig.Columns.TITLE),
-                            beginAt = rs.getString(DatabaseConfig.Columns.BEGIN_AT),
-                            lastUpdated = rs.getString(DatabaseConfig.Columns.LAST_UPDATED)
-                        ))
-                    }
-                }
-            }
-        }
-    }
-
-    fun closeConnection() {
-        connection?.close()
-        connection = null
-    }
-}
-
-fun initCalendar(accessGCtoken: String, access42token: String) = runBlocking {
-    try {
-        println("Deleting all calendar events...")
-        deleteAllEvents(accessGCtoken)
-
-        println("Fetching 42 events...")
-        val allEvents = fetchAllCampusEvents(access42token)
-        println("Total events fetched: ${allEvents.size}")
-
-        println("Initializing database...")
-        val dbManager = DatabaseManager.getInstance()
-
-        println("Uploading events to GCal...")
-        try {
-            for (event in allEvents) {
-                val eventGCalID = createGCalEvent(accessGCtoken, event)
-                try {
-                    dbManager.upsertEvent(event.id, eventGCalID, event.name, event.beginAt, event.updatedAt)
-                } catch (e: Exception) {
-                    println("Failed to save event ${event.id} to database: ${e.message}")
-                    break
-                }
-            }
-        } finally {
-            dbManager.closeConnection()
-        }
-    }
-    catch (e: Exception) {
-        println("Error occurred: ${e.message}")
-    }
-}

--- a/src/main/kotlin/utils.kt
+++ b/src/main/kotlin/utils.kt
@@ -211,17 +211,17 @@ fun initCalendar(accessGCtoken: String, access42token: String) = runBlocking {
         println("Deleting all calendar events...")
         deleteAllEvents(accessGCtoken)
 
-//        println("Fetching 42 events...")
-//        val allEvents = fetchAllCampusEvents(access42token)
-//        println("Total events fetched: ${allEvents.size}")
-//
-//        println("Uploading events to Gcal...")
-//        val uploadEvents = allEvents.map {
-//            it.toGCalEvent()
-//        }
-//        val jsonEvent = Json.encodeToString(uploadEvents.first())
-//        println(jsonEvent)
-        //insertCalendarEvents(accessGCtoken, uploadEvents)
+        println("Fetching 42 events...")
+        val allEvents = fetchAllCampusEvents(access42token)
+        println("Total events fetched: ${allEvents.size}")
+
+        println("Uploading events to Gcal...")
+        val uploadEvents = allEvents.map {
+            it.toGCalEvent()
+        }
+        val jsonEvent = Json.encodeToString(uploadEvents.first())
+        println(jsonEvent)
+        insertCalendarEvents(accessGCtoken, uploadEvents)
     }
     catch (e: Exception) {
         println("Error occurred: ${e.message}")


### PR DESCRIPTION
Sync event from 42 to Gcal **only if the event is updated**. Ignore already up-to-date events.

This patch adds an SQLite database with an events TABLE and minimal fields ( 42 ID, GCal ID, title, begin_at, last_updated) that store the relation between both event type IDs and the updated time. The initialization function now calls the previously developed `deleteAllEvents` and `fetchAllCampusEvents` but now it also initializes the db and populates it with the events data.

After this, the main `syncEvents` function will call `fetchUpdatedCampusEvents` and will compare the update time of these events with the database. Based on this will `POST` a new event, `PUT` an updated event or do nothing. These changes make the number of calls minimal.