### PR TITLE
:hammer: refactor: optimize AWS for cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+src/main/resources/
 event42sync.json
 .gradle
 build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
     implementation("com.amazonaws:aws-lambda-java-core:1.2.3")
     implementation("com.amazonaws:aws-lambda-java-events:3.11.3")
     implementation("com.amazonaws:aws-java-sdk-ssm:1.12.+")
+
+    // AWS S3 SDK
+    implementation("software.amazon.awssdk:s3:2.20.26")
 }
 
 application {

--- a/src/main/kotlin/com/Event42Sync/HttpClientConfig.kt
+++ b/src/main/kotlin/com/Event42Sync/HttpClientConfig.kt
@@ -1,0 +1,23 @@
+package com.Event42Sync
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.HttpTimeout
+
+object HttpClientConfig {
+    fun createClient(): HttpClient = HttpClient(CIO) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30000  // 30 seconds
+            connectTimeoutMillis = 15000  // 15 seconds
+            socketTimeoutMillis = 15000   // 15 secondsº
+        }
+        engine {
+            requestTimeout = 30000  // 30 seconds
+            endpoint {
+                connectTimeout = 15000  // 15 seconds
+                keepAliveTime = 5000   // 5 seconds
+                maxConnectionsCount = 1000
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/Event42Sync/Main.kt
+++ b/src/main/kotlin/com/Event42Sync/Main.kt
@@ -53,7 +53,7 @@ suspend fun fetch42AccessToken(): String {
     val clientId = Config.get("UID")
     val clientSecret = Config.get("SECRET")
 
-    val client = HttpClient()
+    val client = HttpClientConfig.createClient()
 
     try {
         val response: HttpResponse = client.post("https://api.intra.42.fr/oauth/token") {
@@ -156,7 +156,7 @@ data class GCalEventsResponse(
 )
 
 suspend fun fetchUpdatedCampusEvents(access_token: String): List<Event42> {
-    val client = HttpClient(CIO)
+    val client = HttpClientConfig.createClient()
     val allEvent42s = mutableListOf<Event42>()
     var currentPage = 1
     val pageSize = 30 // Number of results per page
@@ -267,7 +267,7 @@ suspend fun createGCalEvent(
 ): String? {
 
     val calendarId = Config.get("CALENDAR_ID")
-    val client = HttpClient(CIO)
+    val client = HttpClientConfig.createClient()
     try {
         // Transform Event42 to EventGCal and Nullify non-required fields
         val uploadEvent = event.toGCalEvent().toUploadEvent()
@@ -358,7 +358,7 @@ fun syncEvents(access42token: String, accessGCtoken: String) = runBlocking {
 
 suspend fun updateGCalEvent(accessGCtoken: String, gcalEventId: String, event42: Event42) {
     val calendarId =Config.get("CALENDAR_ID")
-    val client = HttpClient(CIO)
+    val client = HttpClientConfig.createClient()
     try {
         // Transform Event42 to EventGCal and Nullify non-required fields
         val uploadEvent = event42.toGCalEvent().toUploadEvent()

--- a/src/main/kotlin/com/Event42Sync/Main.kt
+++ b/src/main/kotlin/com/Event42Sync/Main.kt
@@ -391,7 +391,7 @@ fun main() = runBlocking {
         println("GC Access Token: $accessGCtoken")
 
         // init_calendar
-        // reinitializeCalendar(accessGCtoken, access42Token)
+        reinitializeCalendar(accessGCtoken, access42Token)
 
         // daily sync
         syncEvents(access42Token, accessGCtoken)

--- a/src/main/kotlin/com/Event42Sync/Main.kt
+++ b/src/main/kotlin/com/Event42Sync/Main.kt
@@ -81,12 +81,8 @@ suspend fun fetch42AccessToken(): String {
 fun fetchGCAccessToken(): String {
     val credentials = if (System.getenv("AWS_LAMBDA_FUNCTION_NAME") != null) {
         // We're in AWS Lambda
-        val ssmClient = AWSSimpleSystemsManagementClientBuilder.defaultClient()
-        val privateKey = ssmClient.getParameter(
-            GetParameterRequest()
-                .withName("/event42sync/gc-private-key")
-                .withWithDecryption(true)
-        ).parameter.value
+        val privateKey = object {}.javaClass.getResourceAsStream("/gc_private_key.txt")?.bufferedReader()?.use { it.readText() }
+            ?: throw IllegalStateException("Could not read private key file")
 
         ServiceAccountCredentials.fromStream("""
             {

--- a/src/main/kotlin/com/Event42Sync/init.kt
+++ b/src/main/kotlin/com/Event42Sync/init.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 
 suspend fun fetchAllCampusEvents(access_token:String): List<Event42> {
-    val client = HttpClient(CIO)
+    val client = HttpClientConfig.createClient()
     val allEvent42s = mutableListOf<Event42>()
     var currentPage = 1
     val pageSize = 30 // Number of results per page


### PR DESCRIPTION
Revert the Postgres database into the SQLite database.

This allowed me to upload the database into a S3 and stop using RDS, which needed a NAT configuration to talk between the lambda and the database. The NAT is not included in the Free Tier and the costs were adding up.

This patch also removes the use of SSM service to handle the private key (too long to be set in the normal lambda environs) and is uploaded directly with the Jar file. This is not an optimal solution and will be changed into using S3 to store the encrypted key.

After removing all these unnecessary services, the cost shall be almost zero.